### PR TITLE
fix(sam3d): correct ROOT path in worker files

### DIFF
--- a/tools/sam3d/sam3_worker.py
+++ b/tools/sam3d/sam3_worker.py
@@ -11,7 +11,7 @@ import sys
 import numpy as np
 from PIL import Image
 
-ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.append(os.path.join(ROOT, "utils", "sam3"))
 
 from sam3.model.sam3_image_processor import Sam3Processor

--- a/tools/sam3d/sam3d_worker.py
+++ b/tools/sam3d/sam3d_worker.py
@@ -14,7 +14,7 @@ import numpy as np
 import torch
 from pytorch3d.transforms import Transform3d, quaternion_to_matrix
 
-ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.append(os.path.join(ROOT, "utils", "sam3d", "notebook"))
 sys.path.append(os.path.join(ROOT, "utils", "sam3d"))
 

--- a/tools/sam3d/sam_worker.py
+++ b/tools/sam3d/sam_worker.py
@@ -17,7 +17,7 @@ import numpy as np
 import torch
 from PIL import Image
 
-ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.append(ROOT)
 sys.path.append(os.path.join(ROOT, "utils", "sam"))
 sys.path.append(os.path.join(ROOT, "utils"))


### PR DESCRIPTION
Worker files were moved from tools/utils/ to tools/sam3d/ but their ROOT paths weren't updated. They were pointing to tools/ instead of project root, causing utils/sam/ paths to be unreachable.
This pull request updates the way the `ROOT` directory is defined in three worker scripts under the `tools/sam3d` directory. The change ensures that the `ROOT` variable points one level higher in the directory structure, which will affect how relative imports and module paths are resolved in these scripts.

Path resolution updates:

* Updated the `ROOT` variable in `sam3_worker.py`, `sam3d_worker.py`, and `sam_worker.py` to use `os.path.join(os.path.dirname(__file__), "..", "..")` instead of just one parent directory. This change ensures that all three scripts consistently reference the correct project root for subsequent path operations. [[1]](diffhunk://#diff-3396b1988aadd73de891fe16a9070734fc7fdc2fa9db334a8f9534718419ea53L14-R14) [[2]](diffhunk://#diff-7dd203c1db0bbb756dc23883c1ca2c7f1e614af550c871a45ebe521491d5010aL17-R17) [[3]](diffhunk://#diff-fa87086d4b7ba253554f26e7c80e1459b27e83d387ddbdee86902cdca01e3e3bL20-R20)