### PR TITLE
reorganize and fixed several feature problems. 

### DIFF
--- a/requirements/readme.md
+++ b/requirements/readme.md
@@ -355,7 +355,7 @@ python --version  # Should be 3.11 for Blender
 sudo apt-get install -y build-essential cmake
 
 # Try manual installation
-cd utils/infinigen
+cd utils/third_party/infinigen
 bash scripts/install/interactive_blender.sh 2>&1 | tee install.log
 
 # Check install.log for specific errors

--- a/runners/readme.md
+++ b/runners/readme.md
@@ -170,7 +170,7 @@ python main.py --mode <mode> --model <model> [options]
 
 | Argument | Description | Default |
 |----------|-------------|---------|
-| `--blender-command` | Path to Blender executable | utils/infinigen/blender/blender |
+| `--blender-command` | Path to Blender executable | utils/third_party/infinigen/blender/blender |
 | `--blender-file` | Blender template file | None |
 | `--blender-script` | Blender execution script | data/blendergym/pipeline_render_script.py |
 | `--gpu-devices` | GPU devices for rendering | From CUDA_VISIBLE_DEVICES |

--- a/runners/slidebench/library/library.py
+++ b/runners/slidebench/library/library.py
@@ -2,6 +2,11 @@
 
 Provides all slide manipulation functions including text, images, and AI generation.
 """
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "utils", "third_party", "slides"))
+
 from pptx.util import Inches, Pt
 from pptx.dml.color import RGBColor
 from pptx.enum.text import MSO_AUTO_SIZE

--- a/runners/slidebench/library/library_basic.py
+++ b/runners/slidebench/library/library_basic.py
@@ -2,6 +2,11 @@
 
 Provides text, title, bullet point, and image manipulation functions for PowerPoint slides.
 """
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "utils", "third_party", "slides"))
+
 from pptx.util import Inches, Pt
 from pptx.dml.color import RGBColor
 from pptx.enum.text import MSO_AUTO_SIZE

--- a/runners/slidebench/library/library_image.py
+++ b/runners/slidebench/library/library_image.py
@@ -2,6 +2,11 @@
 
 Provides Google search and DALL-E image generation functions for slides.
 """
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "utils", "third_party", "slides"))
+
 from SlidesLib import GoogleSearch, Dalle3
 
 def google_search_screenshot(question: str, save_path: str = "screenshot.png") -> str:

--- a/tools/sam3d/bridge.py
+++ b/tools/sam3d/bridge.py
@@ -80,7 +80,7 @@ def initialize(args: Dict[str, object]) -> Dict[str, object]:
     _output_dir = args.get("output_dir") + "/sam"
     os.makedirs(_output_dir, exist_ok=True)
     _sam3_cfg = args.get("sam3d_config_path") or os.path.join(
-        ROOT, "utils", "sam3d", "checkpoints", "hf", "pipeline.yaml"
+        ROOT, "utils", "third_party", "sam3d", "checkpoints", "hf", "pipeline.yaml"
     )
     _blender_command = args.get("blender_command") or "utils/third_party/infinigen/blender/blender"
     return {

--- a/tools/sam3d/init.py
+++ b/tools/sam3d/init.py
@@ -131,7 +131,7 @@ def initialize(args: Dict[str, object]) -> Dict[str, object]:
         _log_file = open(log_path, 'w', encoding='utf-8')
         log(f"[SAM_INIT] Initialized. Log file: {log_path}")
         _sam3_cfg = args.get("sam3d_config_path") or os.path.join(
-            ROOT, "utils", "sam3d", "checkpoints", "hf", "pipeline.yaml"
+            ROOT, "utils", "third_party", "sam3d", "checkpoints", "hf", "pipeline.yaml"
         )
         _blender_command = args.get("blender_command") or "utils/third_party/infinigen/blender/blender"
         # Record the passed blender_file parameter for later writing directly to that path during reconstruction

--- a/tools/sam3d/sam3_worker.py
+++ b/tools/sam3d/sam3_worker.py
@@ -12,7 +12,7 @@ import numpy as np
 from PIL import Image
 
 ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-sys.path.append(os.path.join(ROOT, "utils", "sam3"))
+sys.path.append(os.path.join(ROOT, "utils", "third_party", "sam3"))
 
 from sam3.model.sam3_image_processor import Sam3Processor
 from sam3.model_builder import build_sam3_image_model

--- a/tools/sam3d/sam3d_worker.py
+++ b/tools/sam3d/sam3d_worker.py
@@ -15,8 +15,8 @@ import torch
 from pytorch3d.transforms import Transform3d, quaternion_to_matrix
 
 ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
-sys.path.append(os.path.join(ROOT, "utils", "sam3d", "notebook"))
-sys.path.append(os.path.join(ROOT, "utils", "sam3d"))
+sys.path.append(os.path.join(ROOT, "utils", "third_party", "sam3d", "notebook"))
+sys.path.append(os.path.join(ROOT, "utils", "third_party", "sam3d"))
 
 from inference import Inference, load_image
 

--- a/tools/sam3d/sam_worker.py
+++ b/tools/sam3d/sam_worker.py
@@ -19,7 +19,7 @@ from PIL import Image
 
 ROOT: str = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 sys.path.append(ROOT)
-sys.path.append(os.path.join(ROOT, "utils", "sam"))
+sys.path.append(os.path.join(ROOT, "utils", "third_party", "sam"))
 sys.path.append(os.path.join(ROOT, "utils"))
 
 from common import build_client, get_image_base64
@@ -270,7 +270,7 @@ def main() -> None:
 
     # Set default checkpoint path
     if args.checkpoint is None:
-        args.checkpoint = os.path.join(ROOT, "utils", "sam", "sam_vit_h_4b8939.pth")
+        args.checkpoint = os.path.join(ROOT, "utils", "third_party", "sam", "sam_vit_h_4b8939.pth")
 
     # Load image
     image = cv2.imread(args.image)

--- a/utils/third_party/slides/SlidesLib/__init__.py
+++ b/utils/third_party/slides/SlidesLib/__init__.py
@@ -1,0 +1,10 @@
+"""SlidesLib - PowerPoint slide generation utilities."""
+
+from .llm import LLM
+from .image_gen import Dalle3
+from .search import GoogleSearch
+from .plotting import Plotting
+from .ppt_gen import SlideAgent
+from .vqa import VQA
+
+__all__ = ["LLM", "Dalle3", "GoogleSearch", "Plotting", "SlideAgent", "VQA"]

--- a/utils/third_party/slides/library/library.py
+++ b/utils/third_party/slides/library/library.py
@@ -1,4 +1,9 @@
 """PPTX helper functions for slide manipulation and external services."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
 from pptx.dml.color import RGBColor
 from pptx.enum.text import MSO_AUTO_SIZE
 from pptx.util import Inches, Pt

--- a/utils/third_party/slides/library/library_basic.py
+++ b/utils/third_party/slides/library/library_basic.py
@@ -1,4 +1,9 @@
 """Basic PPTX helper functions for slide manipulation."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
 from pptx.dml.color import RGBColor
 from pptx.enum.text import MSO_AUTO_SIZE
 from pptx.util import Inches, Pt

--- a/utils/third_party/slides/library/library_image.py
+++ b/utils/third_party/slides/library/library_image.py
@@ -1,4 +1,9 @@
 """Image search and generation helper functions."""
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
 from SlidesLib import Dalle3, GoogleSearch
 
 def google_search_screenshot(question: str, save_path: str = "screenshot.png") -> str:


### PR DESCRIPTION
This pull request reorganizes several dependencies by updating import paths and default file locations to reference new locations under the `utils/third_party` directory. Additionally, it introduces new initialization code for the `SlidesLib` utilities and ensures all related modules can be imported correctly. The changes primarily focus on improving the project structure and maintainability by centralizing third-party code.

**Third-party dependency path updates:**

* Updated all references to `infinigen`, `sam`, and `sam3d` in scripts and documentation to use the new `utils/third_party` directory structure instead of the previous `utils` location. This includes changes in Blender command paths, configuration files, and checkpoint files in both code and documentation. [[1]](diffhunk://#diff-294dc23d2892cfb3d01f2448f7391b880f36d06ba4f55d8b8845d1c8dd8025faL358-R358) [[2]](diffhunk://#diff-82b46b9b1da6091e34aea9e520d06873cf2f82636932f0f7ea81c32f3105dff2L173-R173) [[3]](diffhunk://#diff-11e3287d321137297a2745726ed6dab656473b9801833abd4f657f9ceb5bc371L83-R83) [[4]](diffhunk://#diff-41e694d8873e84bc9b26bbe2552c15de4d28239359c70830fd4fab2a41f9f2b7L134-R134) [[5]](diffhunk://#diff-3396b1988aadd73de891fe16a9070734fc7fdc2fa9db334a8f9534718419ea53L15-R15) [[6]](diffhunk://#diff-7dd203c1db0bbb756dc23883c1ca2c7f1e614af550c871a45ebe521491d5010aL18-R19) [[7]](diffhunk://#diff-fa87086d4b7ba253554f26e7c80e1459b27e83d387ddbdee86902cdca01e3e3bL22-R22) [[8]](diffhunk://#diff-fa87086d4b7ba253554f26e7c80e1459b27e83d387ddbdee86902cdca01e3e3bL273-R273)

**SlidesLib integration and import handling:**

* Added import path initialization in all `runners/slidebench/library` modules to include the new `utils/third_party/slides` directory, ensuring that `SlidesLib` and its components can be imported without issues. [[1]](diffhunk://#diff-2dfbec03a3df779ccbb86f52a4e1e9e0d586e0c36d449110bee94ccf7df13a93R5-R9) [[2]](diffhunk://#diff-ee69ac50e70356aae074decaa5ef03ef57bce9f95a45353c78413146b33e5148R5-R9) [[3]](diffhunk://#diff-f72bad0f34c53ba3b3e53a0d2d3655c8a2cea614e97986660906195fea6e5f53R5-R9)
* Added similar import path handling to the `utils/third_party/slides/library` modules for consistency and to prevent import errors. [[1]](diffhunk://#diff-692eb898bdef1add9fd694e009ef487f1a0680433ea0652b77a70681d9ee5930R2-R6) [[2]](diffhunk://#diff-ca973296b384307c365a86c81480a4976ae3845c0ccb59dd7199438aefe829acR2-R6) [[3]](diffhunk://#diff-e668ba4b5fcfc3ab57bc2ae13b1b2ffdda93411018bf872e73aaee67d74ffb1dR2-R6)

**SlidesLib module initialization:**

* Introduced an `__init__.py` file for `SlidesLib` to expose its main utilities (`LLM`, `Dalle3`, `GoogleSearch`, `Plotting`, `SlideAgent`, `VQA`) for easier and more reliable imports.Update all paths after utils/ reorganization:
- utils/infinigen → utils/third_party/infinigen
- utils/sam → utils/third_party/sam
- utils/sam3 → utils/third_party/sam3
- utils/sam3d → utils/third_party/sam3d

Add SlidesLib/__init__.py for proper module imports. Add sys.path setup in library files to find SlidesLib.

Files updated:
- tools/sam3d/*.py: SAM path references
- runners/slidebench/library/*.py: SlidesLib imports
- utils/third_party/slides/library/*.py: SlidesLib imports
- requirements/readme.md, runners/readme.md: doc paths