### PR TITLE
render SAM3D-reconstructed scene and feed it to the generator

### DIFF
--- a/agents/generator.py
+++ b/agents/generator.py
@@ -75,8 +75,19 @@ class GeneratorAgent:
         try:
             if any("init.py" in server for server in self.tool_client.tool_servers):
                 print("=== Auto-calling init.reconstruct_full_scene to initialize scene ===")
-                _ = await self.tool_client.call_tool("reconstruct_full_scene", {})
+                init_result = await self.tool_client.call_tool("reconstruct_full_scene", {})
                 print("=== init.reconstruct_full_scene finished ===")
+
+                init_render_path = (init_result or {}).get("data", {}).get("init_render_path")
+                if init_render_path and os.path.exists(init_render_path):
+                    print(f"=== Attaching SAM3D init render to memory: {init_render_path} ===")
+                    self.memory.append({
+                        "role": "user",
+                        "content": [
+                            {"type": "image_url", "image_url": {"url": get_image_base64(init_render_path)}},
+                            {"type": "text", "text": f"Initial image loaded from local path: {init_render_path}. This is a preview of the SAM3D-reconstructed scene the generator starts from. The objects shown above are already imported into the Blender file; manipulate them rather than re-creating them from scratch."},
+                        ],
+                    })
         except Exception as e:
             print(f"Warning: auto init reconstruct_full_scene failed: {e}")
 

--- a/tools/blender/glb_import.py
+++ b/tools/blender/glb_import.py
@@ -14,11 +14,11 @@ import bpy
 from mathutils import Euler, Vector
 
 
-def parse_args() -> Tuple[str, str]:
+def parse_args() -> Tuple[str, str, Optional[str]]:
     """Parse command line arguments.
 
     Returns:
-        Tuple of (transforms_json_path, blend_output_path).
+        Tuple of (transforms_json_path, blend_output_path, optional render_path).
 
     Raises:
         SystemExit: If required arguments are not provided.
@@ -26,7 +26,7 @@ def parse_args() -> Tuple[str, str]:
     argv = sys.argv
     if "--" not in argv:
         print("[ERROR] Usage:")
-        print("  blender -b -P import_glbs_to_blend.py -- transforms.json output.blend")
+        print("  blender -b -P import_glbs_to_blend.py -- transforms.json output.blend [render.png]")
         sys.exit(1)
     idx = argv.index("--")
     if len(argv) < idx + 3:
@@ -34,7 +34,8 @@ def parse_args() -> Tuple[str, str]:
         sys.exit(1)
     transforms_json_path = os.path.abspath(argv[idx + 1])
     blend_path = os.path.abspath(argv[idx + 2])
-    return transforms_json_path, blend_path
+    render_path = os.path.abspath(argv[idx + 3]) if len(argv) > idx + 3 else None
+    return transforms_json_path, blend_path, render_path
 
 def clear_scene() -> None:
     """Delete all existing objects in the scene."""
@@ -188,9 +189,26 @@ def save_blend(path: str) -> None:
     print(f"[INFO] Saved: {path}")
 
 
+def render_scene(render_path: str) -> None:
+    """Render the current scene to a PNG file.
+
+    Args:
+        render_path: Output path for the rendered image.
+    """
+    os.makedirs(os.path.dirname(render_path), exist_ok=True)
+    scene = bpy.context.scene
+    cameras = [obj for obj in bpy.data.objects if obj.type == 'CAMERA']
+    if cameras:
+        scene.camera = cameras[0]
+    scene.render.image_settings.file_format = 'PNG'
+    scene.render.filepath = render_path
+    bpy.ops.render.render(write_still=True)
+    print(f"[INFO] Rendered initial scene to: {render_path}")
+
+
 def main() -> None:
     """Main entry point for the GLB importer script."""
-    transforms_json_path, blend_path = parse_args()
+    transforms_json_path, blend_path, render_path = parse_args()
     print(f"[INFO] Loading transforms from: {transforms_json_path}")
     print(f"[INFO] Output: {blend_path}")
 
@@ -221,6 +239,13 @@ def main() -> None:
     print(f"[INFO] Successfully imported {success_count}/{len(objects_data)} GLB files")
 
     save_blend(blend_path)
+
+    if render_path:
+        try:
+            render_scene(render_path)
+        except Exception as e:
+            print(f"[WARN] Failed to render initial scene: {e}")
+
     print("[INFO] Done.")
 
 

--- a/tools/sam3d/init.py
+++ b/tools/sam3d/init.py
@@ -384,6 +384,9 @@ def reconstruct_full_scene() -> Dict[str, object]:
         with open(transforms_json_path, 'w') as f:
             json.dump(object_transforms, f, indent=2)
 
+        # Render initial scene preview alongside the .blend so the agent can see it
+        init_render_path = os.path.join(_output_dir, "render1.png")
+
         # Build Blender command
         blender_cmd = [
             _blender_command,
@@ -393,6 +396,7 @@ def reconstruct_full_scene() -> Dict[str, object]:
             "--",
             transforms_json_path,  # Pass position information JSON file path
             blend_path,  # Output .blend file path
+            init_render_path,  # Output initial scene render
         ]
 
         blender_log_path = os.path.join(_output_dir, "blender_import.log")
@@ -416,6 +420,7 @@ def reconstruct_full_scene() -> Dict[str, object]:
             if file.endswith(".blend1"):
                 os.remove(os.path.join(os.path.dirname(_output_dir), file))
         
+        rendered_init = init_render_path if os.path.exists(init_render_path) else None
         return {
             "status": "success",
             "output": {
@@ -426,7 +431,8 @@ def reconstruct_full_scene() -> Dict[str, object]:
                     "blend_path": blend_path,
                     "num_objects": len(glb_paths),
                     "num_masks": len(masks),
-                    "glb_paths": glb_paths
+                    "glb_paths": glb_paths,
+                    "init_render_path": rendered_init,
                 }
             }
         }


### PR DESCRIPTION
Without an initial render, the generator only saw the target image and had to rely on get_scene_info text output to know what SAM3D had imported. The init prompt then competed with initialize_plan's "you must call this tool first" rule, and the agent often regenerated assets from scratch instead of manipulating the SAM3D objects.

glb_import.py now optionally renders to a PNG after saving the .blend; sam3d/init.py passes the render path through and surfaces it in the tool result; the generator picks it up after auto-init and appends it as a user-role image+text to memory, so the agent sees the actual SAM3D scene before its first turn.

Validated end-to-end on christmas1 (H100): 11/11 GLBs reconstructed, render1.png produced, memory[2] contains the init image, and the generator's first tool call was get_scene_info (matching the init prompt).